### PR TITLE
Add hamburger menu for month navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,9 +41,35 @@ details.activities summary{cursor:pointer;font-weight:600}
 .activities ul{margin:.5rem 0 0 1.5rem;padding-left:0}
 .activities li{line-height:1.4;list-style:disc}
 time{font-variant-numeric:tabular-nums}
+header{position:relative;margin-bottom:1rem}
+#menuButton{background:none;border:0;width:30px;height:25px;padding:0;display:flex;flex-direction:column;justify-content:space-between;cursor:pointer}
+#menuButton span{display:block;height:3px;background:#333;border-radius:2px;transition:transform .3s,opacity .3s}
+#menuButton.open span:nth-child(1){transform:translateY(9px) rotate(45deg)}
+#menuButton.open span:nth-child(2){opacity:0}
+#menuButton.open span:nth-child(3){transform:translateY(-9px) rotate(-45deg)}
+#monthNav{position:absolute;top:100%;left:0;right:0;background:#fff;border:1px solid #ddd;max-height:0;overflow:hidden;transition:max-height .3s ease;box-shadow:0 2px 4px rgba(0,0,0,.2)}
+#monthNav.open{max-height:200px}
+#monthNav a{display:block;padding:.5rem 1rem;text-decoration:none;color:#333}
+#monthNav a:hover{background:#f0f0f0}
 </style>
 </head>
 <body>
+
+<header>
+  <button id="menuButton" aria-label="Menu"><span></span><span></span><span></span></button>
+  <nav id="monthNav">
+    <a href="/">Juni 2025</a>
+    <a href="may/">Mei 2025</a>
+  </nav>
+</header>
+<script>
+  const btn = document.getElementById('menuButton');
+  const nav = document.getElementById('monthNav');
+  btn.addEventListener('click', ()=>{
+    btn.classList.toggle('open');
+    nav.classList.toggle('open');
+  });
+</script>
 
 <h1>Juni‑minuten 2025</h1>
 <p id="targetToday" style="font-weight:500"></p>

--- a/may/index.html
+++ b/may/index.html
@@ -41,9 +41,35 @@ details.activities summary{cursor:pointer;font-weight:600}
 .activities ul{margin:.5rem 0 0 1.5rem;padding-left:0}
 .activities li{line-height:1.4;list-style:disc}
 time{font-variant-numeric:tabular-nums}
+header{position:relative;margin-bottom:1rem}
+#menuButton{background:none;border:0;width:30px;height:25px;padding:0;display:flex;flex-direction:column;justify-content:space-between;cursor:pointer}
+#menuButton span{display:block;height:3px;background:#333;border-radius:2px;transition:transform .3s,opacity .3s}
+#menuButton.open span:nth-child(1){transform:translateY(9px) rotate(45deg)}
+#menuButton.open span:nth-child(2){opacity:0}
+#menuButton.open span:nth-child(3){transform:translateY(-9px) rotate(-45deg)}
+#monthNav{position:absolute;top:100%;left:0;right:0;background:#fff;border:1px solid #ddd;max-height:0;overflow:hidden;transition:max-height .3s ease;box-shadow:0 2px 4px rgba(0,0,0,.2)}
+#monthNav.open{max-height:200px}
+#monthNav a{display:block;padding:.5rem 1rem;text-decoration:none;color:#333}
+#monthNav a:hover{background:#f0f0f0}
 </style>
 </head>
 <body>
+
+<header>
+  <button id="menuButton" aria-label="Menu"><span></span><span></span><span></span></button>
+  <nav id="monthNav">
+    <a href="../">Juni 2025</a>
+    <a href="./">Mei 2025</a>
+  </nav>
+</header>
+<script>
+  const btn = document.getElementById('menuButton');
+  const nav = document.getElementById('monthNav');
+  btn.addEventListener('click', ()=>{
+    btn.classList.toggle('open');
+    nav.classList.toggle('open');
+  });
+</script>
 
 <h1>Mei‑kilometers 2025</h1>
 <p id="targetToday" style="font-weight:500"></p>


### PR DESCRIPTION
## Summary
- add header with animated hamburger menu
- include month navigation menu to switch between May and June

## Testing
- `npm test` *(fails: package.json missing)*
- `make test` *(fails: no rule)*

------
https://chatgpt.com/codex/tasks/task_e_683ee351d59483289c8091cc454219ba