### PR TITLE
Fix duration tracking for Strava data

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@ function fillActivitiesList(id, acts){
     .filter(a=>a.date.startsWith(YEAR_MONTH))
     .sort((a,b)=>a.date.localeCompare(b.date))
     .map(a=>{
-      const min = a.minutes ?? a.km*10;
+      const min = a.minutes ?? (a.moving_time ? a.moving_time/60 : (a.elapsed_time ? a.elapsed_time/60 : 0));
       return `<li><time datetime="${a.date}">${a.date}</time> – ${a.type} – ${min.toFixed(0)} min – ${a.name}</li>`;
     })
     .join('');
@@ -139,7 +139,7 @@ function dailyCumulative(acts){
   acts.forEach(a=>{
     if (!a.date.startsWith(YEAR_MONTH)) return;
     const d = +a.date.slice(8,10);
-    const min = a.minutes ?? a.km*10;
+    const min = a.minutes ?? (a.moving_time ? a.moving_time/60 : (a.elapsed_time ? a.elapsed_time/60 : 0));
     perDay[d-1] += min;
   });
   let sum=0; return perDay.map(m=>sum+=m);
@@ -150,7 +150,7 @@ const datasetPromises = people.map(async ({id,label})=>{
   const acts = await fetch(`data/${id}/raw-activities.json`).then(r=>r.json());
 
   const totalMin = acts.filter(a=>a.date.startsWith(YEAR_MONTH))
-                       .reduce((s,a)=>s+(a.minutes ?? a.km*10),0);
+                       .reduce((s,a)=>s+(a.minutes ?? (a.moving_time ? a.moving_time/60 : (a.elapsed_time ? a.elapsed_time/60 : 0))),0);
   document.getElementById(`${id}-min`).textContent = totalMin.toFixed(0);
   updatePie(document.getElementById(`progress-${id}`), Math.round(totalMin/GOAL_MIN*100));
   fillActivitiesList(id, acts);

--- a/scripts/update-strava.js
+++ b/scripts/update-strava.js
@@ -6,7 +6,7 @@
  * ▸ Bewaart per atleet   ▸  data/<user>/raw-activities.json
  *                        ▸  data/<user>/monthly_walk_hike.json
  *
- *   – raw‑activiteiten:  id, date, type, km, name
+ *   – raw‑activiteiten:  alle fields van de Strava API + date, km, minutes
  *   – maandtotalen:      month(YYYY‑MM) + km (alleen Walk/Hike‑types)
  *
  * Omgevingsvariabelen (repo ▸ Settings ▸ Secrets ▸ Actions)
@@ -74,11 +74,10 @@ async function fetchAllActivities(token) {
 function buildRaw(acts) {
   return acts
     .map((a) => ({
-      id:   a.id,
-      date: a.start_date_local.slice(0, 10), // YYYY‑MM‑DD
-      type: a.type,
-      km:   +(a.distance / 1000).toFixed(2),
-      name: a.name,
+      ...a,
+      date:    a.start_date_local.slice(0, 10), // YYYY‑MM‑DD
+      km:      +(a.distance / 1000).toFixed(2),
+      minutes: Math.round(a.moving_time / 60),
     }))
     .sort((a, b) => a.date.localeCompare(b.date));
 }


### PR DESCRIPTION
## Summary
- preserve complete Strava activity objects and store duration in minutes
- compute progress using activity length instead of distance

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684041d070288328946e27756243b3da