### PR TITLE
Add celebration confetti when goals are met

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
   <!-- +++ PWA END +++ -->
 
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js"></script>
 
 <style>
 body{font-family:system-ui;margin:0 auto;max-width:800px;padding:2rem;background:#f7f7f7}
@@ -145,6 +146,18 @@ function dailyCumulative(acts){
   let sum=0; return perDay.map(m=>sum+=m);
 }
 
+const goalsMet = {};
+function checkGoals(){
+  if (people.every(p=>goalsMet[p.id])){
+    if(typeof confetti==='function'){
+      confetti({particleCount:100,spread:70});
+      setTimeout(()=>confetti({particleCount:150,spread:90}),250);
+    }else{
+      alert('Gefeliciteerd! Alle doelen behaald!');
+    }
+  }
+}
+
 /* ───────────── Data & UI ───────────── */
 const datasetPromises = people.map(async ({id,label})=>{
   const acts = await fetch(`data/${id}/raw-activities.json`).then(r=>r.json());
@@ -154,6 +167,9 @@ const datasetPromises = people.map(async ({id,label})=>{
   document.getElementById(`${id}-min`).textContent = totalMin.toFixed(0);
   updatePie(document.getElementById(`progress-${id}`), Math.round(totalMin/GOAL_MIN*100));
   fillActivitiesList(id, acts);
+
+  goalsMet[id] = totalMin >= GOAL_MIN;
+  checkGoals();
 
   return { label, data: dailyCumulative(acts), tension:.3 };
 });

--- a/may/index.html
+++ b/may/index.html
@@ -19,6 +19,7 @@
   <!-- +++ PWA END +++ -->
 
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js"></script>
 
 <style>
 body{font-family:system-ui;margin:0 auto;max-width:800px;padding:2rem;background:#f7f7f7}
@@ -142,6 +143,18 @@ function dailyCumulative(acts){
   let sum=0; return perDay.map(k=>sum+=k);
 }
 
+const goalsMet = {};
+function checkGoals(){
+  if(people.every(p=>goalsMet[p.id])){
+    if(typeof confetti==='function'){
+      confetti({particleCount:100,spread:70});
+      setTimeout(()=>confetti({particleCount:150,spread:90}),250);
+    }else{
+      alert('Gefeliciteerd! Alle doelen behaald!');
+    }
+  }
+}
+
 /* ───────────── Data & UI ───────────── */
 const datasetPromises = people.map(async ({id,label})=>{
   const acts = await fetch(`../data/${id}/raw-activities.json`).then(r=>r.json());
@@ -151,6 +164,9 @@ const datasetPromises = people.map(async ({id,label})=>{
   document.getElementById(`${id}-km`).textContent = totalMay.toFixed(1);
   updatePie(document.getElementById(`progress-${id}`), Math.round(totalMay/GOAL_KM*100));
   fillActivitiesList(id, acts);
+
+  goalsMet[id] = totalMay >= GOAL_KM;
+  checkGoals();
 
   return { label, data: dailyCumulative(acts), tension:.3 };
 });


### PR DESCRIPTION
## Summary
- load canvas-confetti library
- trigger a confetti burst once everyone reaches their goal for the month

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ceb5d37c0832894f0d94a0cf56c4f